### PR TITLE
Resolve module not found error for `react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,16 @@
   "files": [
     "lib"
   ],
+  "dependencies": {
+    "react": "15"
+  },
+  "peerDependencies": {
+    "fbjs": "*",
+    "object-assign": "*"
+  },
   "optionalDependencies": {
     "fbjs": "*",
-    "object-assign": "*",
-    "react": "*"
+    "object-assign": "*"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Exposes the core/internal modules from react-dom lib.",
   "author": "Mark <mark@remarkablemark.org>",
   "scripts": {
-    "prepublish": "npm run clean && npm run copy",
+    "prepublishOnly": "npm run clean && npm run copy",
     "clean": "rm -rf lib",
     "copy": "cp -r node_modules/react-dom/lib/. lib",
     "changelog": "conventional-changelog -p angular -o CHANGELOG.md -s"


### PR DESCRIPTION
Because `react@16` changes the directory structure of the package, make sure to specify `react@15` as a dependency.

Fixes #1