### PR TITLE
chore(package): remove peer- and optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,6 @@
   "dependencies": {
     "react": "15"
   },
-  "peerDependencies": {
-    "fbjs": "*",
-    "object-assign": "*"
-  },
-  "optionalDependencies": {
-    "fbjs": "*",
-    "object-assign": "*"
-  },
   "devDependencies": {
     "react-dom": "^15",
     "standard-version": "^4.3.0"


### PR DESCRIPTION
They are redundant as react@15 have them as regular dependencies so they are installed anyways.