### PR TITLE
refactor(react-property): update build scripts to output `.js` file instead of `.json`

### DIFF
--- a/packages/react-property/README.md
+++ b/packages/react-property/README.md
@@ -67,9 +67,9 @@ const injection = require('react-property/lib/injection');
 .
 ├── index.js
 └── lib
-    ├── HTMLDOMPropertyConfig.json
-    ├── SVGDOMPropertyConfig.json
-    └── injection.json
+    ├── HTMLDOMPropertyConfig.js
+    ├── SVGDOMPropertyConfig.js
+    └── injection.js
 ```
 
 ## License

--- a/packages/react-property/scripts/build-html.js
+++ b/packages/react-property/scripts/build-html.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const prettier = require('prettier');
 const DOMProperty = require('react-dom/lib/DOMProperty');
 const HTMLDOMPropertyConfig = require('react-dom/lib/HTMLDOMPropertyConfig');
-const { LIB_DIR } = require('./constants');
+const { LIB_DIR, PRETTIER_OPTIONS } = require('./constants');
 
 const { HAS_BOOLEAN_VALUE } = DOMProperty.injection;
 
@@ -38,6 +39,9 @@ const properties = {
 };
 
 fs.writeFileSync(
-  path.resolve(LIB_DIR, 'HTMLDOMPropertyConfig.json'),
-  JSON.stringify(properties)
+  path.resolve(LIB_DIR, 'HTMLDOMPropertyConfig.js'),
+  prettier.format(
+    'module.exports=' + JSON.stringify(properties),
+    PRETTIER_OPTIONS
+  )
 );

--- a/packages/react-property/scripts/build-injection.js
+++ b/packages/react-property/scripts/build-injection.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const prettier = require('prettier');
 const DOMProperty = require('react-dom/lib/DOMProperty');
-const { LIB_DIR } = require('./constants');
+const { LIB_DIR, PRETTIER_OPTIONS } = require('./constants');
 
 /**
  * Create output directory (if it doesn't exist).
@@ -13,6 +14,9 @@ try {
 }
 
 fs.writeFileSync(
-  path.resolve(LIB_DIR, 'injection.json'),
-  JSON.stringify(DOMProperty.injection)
+  path.resolve(LIB_DIR, 'injection.js'),
+  prettier.format(
+    'module.exports=' + JSON.stringify(DOMProperty.injection),
+    PRETTIER_OPTIONS
+  )
 );

--- a/packages/react-property/scripts/build-svg.js
+++ b/packages/react-property/scripts/build-svg.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const prettier = require('prettier');
 const SVGDOMPropertyConfig = require('react-dom/lib/SVGDOMPropertyConfig');
-const { LIB_DIR } = require('./constants');
+const { LIB_DIR, PRETTIER_OPTIONS } = require('./constants');
 
 /**
  * Create output directory (if it doesn't exist).
@@ -43,6 +44,9 @@ const properties = {
 };
 
 fs.writeFileSync(
-  path.resolve(LIB_DIR, 'SVGDOMPropertyConfig.json'),
-  JSON.stringify(properties)
+  path.resolve(LIB_DIR, 'SVGDOMPropertyConfig.js'),
+  prettier.format(
+    'module.exports=' + JSON.stringify(properties),
+    PRETTIER_OPTIONS
+  )
 );

--- a/packages/react-property/scripts/constants.js
+++ b/packages/react-property/scripts/constants.js
@@ -2,6 +2,12 @@ const { resolve } = require('path');
 
 const LIB_DIR = resolve(__dirname, '../lib');
 
+const PRETTIER_OPTIONS = {
+  parser: 'babel',
+  singleQuote: true
+};
+
 module.exports = {
-  LIB_DIR
+  LIB_DIR,
+  PRETTIER_OPTIONS
 };


### PR DESCRIPTION
Relates to #11 and remarkablemark/html-react-parser#117

| File/Directory | Current | Updated |
| --- | :-: | :-: |
| `index.js` | 3.2K | 3.2K |
| `lib` | 8K | 10K |

The advantage of `.js` over `.json` is that quotes around the property keys will be stripped, which leads to a smaller bundle size during minification.

Also, webpack wraps the JSON string in `JSON.parse()`, which is less performant than dealing with a POJO (Plain Old JavaScript Object).